### PR TITLE
Add pose-based body part segmentation and export

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# ScreenTracker v2
+
+This demo captures a screen region, runs YOLO detection and optional pose
+segmentation and renders tracked objects.
+
+## Pose based body parts
+
+* Activate by setting `ENABLE_POSE_PARTS=True` in `config.py`.
+* Toggle overlay with **b** or via menu entry "Körperteile anzeigen".
+* Export part boxes with **o** into `captures_parts/` using class ids:
+  * `0` – head
+  * `1` – upper_body
+  * `2` – body
+* Images and labels are saved in YOLO format (`<class> <cx> <cy> <w> <h>` normalised).
+
+### Hotkeys
+
+`b` parts overlay, `o` export parts labels, `r` reload rules, `q`/Esc quit,
+`m` menu.

--- a/config.py
+++ b/config.py
@@ -8,6 +8,19 @@ the prototype contained in :mod:`main`.
 # Path to the YOLO model weights
 MODEL_PATH = "yolov8n.pt"
 
+# Path to the YOLOv8 pose model used when ``ENABLE_POSE_PARTS`` is true
+POSE_MODEL_PATH = "yolov8n-pose.pt"
+
+# Enable computation and rendering of pose based body parts
+ENABLE_POSE_PARTS = True
+
+# Directory to store exported part annotations
+EXPORT_PARTS_DIR = "captures_parts"
+
+# Optional square size to which inference images are resized before running
+# the model.  ``None`` disables explicit resizing.
+INFER_RESIZE: int | None = None
+
 # Default confidence threshold for detections
 CONF_THRES = 0.35
 

--- a/detection.py
+++ b/detection.py
@@ -1,11 +1,16 @@
 """Detection data container used across the project."""
 
 from dataclasses import dataclass
+from typing import Dict, List, Optional, Tuple
+
+
+Keypoint = Tuple[float, float, float]
+PartBox = Tuple[int, int, int, int]
 
 
 @dataclass
 class Detection:
-    """Represents a single detection bounding box."""
+    """Represents a single detection bounding box with optional pose data."""
 
     x1: int
     y1: int
@@ -13,6 +18,8 @@ class Detection:
     y2: int
     cls: int
     conf: float
+    keypoints: Optional[List[Keypoint]] = None
+    parts: Optional[Dict[str, PartBox]] = None
 
     @property
     def cx(self) -> int:

--- a/main.py
+++ b/main.py
@@ -16,6 +16,7 @@ from ultralytics import YOLO
 import config
 from detection import Detection
 from overlay import Drawer, KeyHelper, MenuState
+from pose_parts import compute_parts_for_detection, export_parts_for_training, rescale_keypoints
 from rule_engine import RuleEngine
 from tracker import CentroidTracker
 
@@ -60,7 +61,17 @@ def main() -> None:
 
     signal.signal(signal.SIGINT, handle_sigint)
 
-    model = YOLO(config.MODEL_PATH)
+    pose_enabled = False
+    try:
+        if config.ENABLE_POSE_PARTS:
+            model = YOLO(config.POSE_MODEL_PATH)
+            pose_enabled = True
+        else:
+            model = YOLO(config.MODEL_PATH)
+    except Exception as exc:
+        print(f"[WARN] Pose-Modell konnte nicht geladen werden: {exc}. Parts deaktiviert")
+        pose_enabled = False
+        model = YOLO(config.MODEL_PATH)
     device = "cuda" if torch.cuda.is_available() else "cpu"
     model.to(device)
 
@@ -78,6 +89,7 @@ def main() -> None:
         person_only=config.PERSON_ONLY,
         show_trails=True,
         show_hud=True,
+        show_parts=False,
     )
 
     key = KeyHelper()
@@ -113,20 +125,46 @@ def main() -> None:
                     frame = np.array(sct.grab(monitor))
                 frame = cv2.cvtColor(frame, cv2.COLOR_BGRA2BGR)
 
-                results = model(frame, conf=menu_state.conf_thres, verbose=False)
+                orig_h, orig_w = frame.shape[:2]
+                infer_img = frame
+                sx = sy = 1.0
+                if config.INFER_RESIZE:
+                    infer_img = cv2.resize(frame, (config.INFER_RESIZE, config.INFER_RESIZE))
+                    sx = orig_w / config.INFER_RESIZE
+                    sy = orig_h / config.INFER_RESIZE
+
+                results = model(infer_img, conf=menu_state.conf_thres, verbose=False)
                 r = results[0]
 
                 dets: List[Detection] = []
                 if r.boxes is not None and len(r.boxes) > 0:
-                    xyxy = r.boxes.xyxy.cpu().numpy().astype(int)
+                    xyxy = r.boxes.xyxy.cpu().numpy()
+                    if config.INFER_RESIZE:
+                        xyxy[:, [0, 2]] *= sx
+                        xyxy[:, [1, 3]] *= sy
+                    xyxy = xyxy.astype(int)
                     confs = r.boxes.conf.cpu().numpy()
                     clss = r.boxes.cls.cpu().numpy().astype(int)
-                    for (x1, y1, x2, y2), c, cls in zip(xyxy, confs, clss):
+                    kpts_xy = None
+                    kpts_conf = None
+                    if pose_enabled and r.keypoints is not None:
+                        kpts_xy = r.keypoints.xy.cpu().numpy()
+                        kpts_conf = r.keypoints.conf.cpu().numpy()
+                        if config.INFER_RESIZE:
+                            kpts_xy[:, :, 0] *= sx
+                            kpts_xy[:, :, 1] *= sy
+                    for idx, ((x1, y1, x2, y2), c, cls) in enumerate(zip(xyxy, confs, clss)):
                         if menu_state.person_only and person_id is not None and cls != person_id:
                             continue
-                        dets.append(Detection(x1, y1, x2, y2, int(cls), float(c)))
+                        kps = None
+                        if pose_enabled and kpts_xy is not None:
+                            kps = [(float(x), float(y), float(kpts_conf[idx][j])) for j, (x, y) in enumerate(kpts_xy[idx])]
+                        dets.append(Detection(int(x1), int(y1), int(x2), int(y2), int(cls), float(c), kps))
 
                 dets = engine.apply(dets, frame)
+                if pose_enabled:
+                    for d in dets:
+                        d.parts = compute_parts_for_detection(d, frame.shape[:2])
                 id2box = ct.update([(d.x1, d.y1, d.x2, d.y2) for d in dets])
 
                 annotated = frame.copy()
@@ -136,6 +174,7 @@ def main() -> None:
                     id2box=id2box,
                     trails=ct.trails if menu_state.show_trails else {},
                     show_hud=menu_state.show_hud,
+                    show_parts=menu_state.show_parts and pose_enabled,
                     fps_smooth=fps_smooth,
                     person_only=menu_state.person_only,
                     conf_thres=menu_state.conf_thres,
@@ -173,6 +212,11 @@ def main() -> None:
                         drawer.save_frame(annotated)
                     elif key.is_capture(k):
                         export_for_training(frame, dets, names)
+                    elif key.is_toggle_parts(k) and pose_enabled:
+                        menu_state.show_parts = not menu_state.show_parts
+                        print(f"[INFO] Parts {'ON' if menu_state.show_parts else 'OFF'}")
+                    elif key.is_export_parts(k) and pose_enabled:
+                        export_parts_for_training(frame, dets, config.EXPORT_PARTS_DIR)
                     elif key.is_reload_rules(k):
                         engine.load_rules()
                     elif drawer.menu_open:

--- a/pose_parts.py
+++ b/pose_parts.py
@@ -1,0 +1,190 @@
+"""Utilities for computing and rendering body part boxes from pose keypoints."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from statistics import median
+from typing import Dict, Iterable, List, Optional, Tuple
+
+try:
+    import cv2
+except Exception:  # pragma: no cover - cv2 may be missing in test env
+    cv2 = None
+import os
+import time
+
+from detection import Detection, PartBox
+
+
+# Classes for export mapping
+PART_CLASS_MAP = {"head": 0, "upper_body": 1, "body": 2}
+
+
+@dataclass
+class ImgShape:
+    height: int
+    width: int
+
+
+def _clamp_box(box: Tuple[float, float, float, float], shape: ImgShape) -> PartBox:
+    x1, y1, x2, y2 = box
+    x1 = int(max(0, min(shape.width - 1, x1)))
+    x2 = int(max(0, min(shape.width - 1, x2)))
+    y1 = int(max(0, min(shape.height - 1, y1)))
+    y2 = int(max(0, min(shape.height - 1, y2)))
+    if x2 < x1:
+        x1, x2 = x2, x1
+    if y2 < y1:
+        y1, y2 = y2, y1
+    return x1, y1, x2, y2
+
+
+def compute_parts_for_detection(det: Detection, img_shape: Tuple[int, int]) -> Optional[Dict[str, PartBox]]:
+    """Compute head/upper/body boxes for a detection based on pose keypoints.
+
+    The heuristics favour available keypoints but gracefully fall back to the
+    detection bounding box if data is missing.
+    """
+
+    if not det.keypoints:
+        return None
+
+    h, w = img_shape[:2]
+    shape = ImgShape(h, w)
+
+    def pt(idx: int) -> Optional[Tuple[float, float]]:
+        if idx >= len(det.keypoints):
+            return None
+        x, y, c = det.keypoints[idx]
+        if c <= 0:
+            return None
+        return x, y
+
+    head_pts = [pt(i) for i in range(5) if pt(i) is not None]
+    shoulders = [pt(5), pt(6)]
+    hips = [pt(11), pt(12)]
+
+    # Shoulder line y
+    shoulder_y_vals = [p[1] for p in shoulders if p is not None]
+    if shoulder_y_vals:
+        shoulder_y = median(shoulder_y_vals)
+    else:
+        shoulder_y = det.y1 + (det.y2 - det.y1) * 0.25
+
+    # Hip line y
+    hip_y_vals = [p[1] for p in hips if p is not None]
+    if hip_y_vals:
+        hip_y = median(hip_y_vals)
+    else:
+        hip_y = det.y1 + (det.y2 - det.y1) * 0.6
+
+    # Head box
+    head_x_vals = [p[0] for p in head_pts]
+    if head_x_vals:
+        head_cx = median(head_x_vals)
+    elif shoulder_y_vals:
+        sx_vals = [p[0] for p in shoulders if p is not None]
+        head_cx = median(sx_vals)
+    else:
+        head_cx = det.cx
+
+    if len(shoulders) == 2 and shoulders[0] and shoulders[1]:
+        head_w = abs(shoulders[0][0] - shoulders[1][0])
+    else:
+        head_w = (det.x2 - det.x1) * 0.3
+    head_w = max(20, head_w)
+
+    head_top_vals = [p[1] for p in head_pts]
+    head_top = min(head_top_vals) if head_top_vals else det.y1
+
+    head_box = _clamp_box(
+        (
+            head_cx - head_w / 2,
+            head_top,
+            head_cx + head_w / 2,
+            shoulder_y,
+        ),
+        shape,
+    )
+
+    # Upper body box
+    side_x_vals = [p[0] for p in shoulders + hips if p is not None]
+    if side_x_vals:
+        x1u = min(side_x_vals)
+        x2u = max(side_x_vals)
+    else:
+        x1u, x2u = det.x1, det.x2
+    pad = (det.x2 - det.x1) * 0.05
+    upper_box = _clamp_box((x1u - pad, shoulder_y, x2u + pad, hip_y), shape)
+
+    # Body box
+    all_pts = [p for p in [pt(i) for i in range(len(det.keypoints))] if p is not None]
+    if all_pts:
+        x1b = min(p[0] for p in all_pts)
+        y1b = min(p[1] for p in all_pts)
+        x2b = max(p[0] for p in all_pts)
+        y2b = max(p[1] for p in all_pts)
+        body_box = _clamp_box((x1b, y1b, x2b, y2b), shape)
+    else:
+        body_box = _clamp_box((det.x1, det.y1, det.x2, det.y2), shape)
+
+    return {"head": head_box, "upper_body": upper_box, "body": body_box}
+
+
+def draw_parts_on_image(img, parts: Dict[str, PartBox]) -> None:
+    """Draw semi transparent overlays for computed part boxes."""
+
+    colors = {
+        "head": (0, 255, 255),  # yellow
+        "upper_body": (255, 0, 0),  # blue
+        "body": (0, 255, 0),  # green
+    }
+    overlay = img.copy()
+    for name, box in parts.items():
+        x1, y1, x2, y2 = box
+        if cv2 is not None:
+            cv2.rectangle(overlay, (x1, y1), (x2, y2), colors.get(name, (255, 255, 255)), -1)
+    if cv2 is not None:
+        cv2.addWeighted(overlay, 0.4, img, 0.6, 0, dst=img)
+
+
+def rescale_keypoints(kpts: List[Tuple[float, float, float]], sx: float, sy: float) -> List[Tuple[float, float, float]]:
+    """Rescale keypoints with separate x/y scale factors."""
+
+    scaled = []
+    for x, y, c in kpts:
+        scaled.append((x * sx, y * sy, c))
+    return scaled
+
+
+def export_parts_for_training(frame_bgr, detections: List[Detection], out_dir: str) -> Optional[str]:
+    """Export frame and part annotations for training in YOLO format."""
+
+    if not any(d.parts for d in detections):
+        print("[WARN] Keine Keypoints – Export abgebrochen.")
+        return None
+
+    if not os.path.exists(out_dir):
+        os.makedirs(out_dir, exist_ok=True)
+
+    ts = time.strftime("%Y%m%d_%H%M%S")
+    img_path = os.path.join(out_dir, f"cap_{ts}.jpg")
+    txt_path = os.path.join(out_dir, f"cap_{ts}.txt")
+
+    if cv2 is not None:
+        cv2.imwrite(img_path, frame_bgr)
+
+    h, w = frame_bgr.shape[:2]
+    with open(txt_path, "w", encoding="utf-8") as f:
+        for d in detections:
+            if not d.parts:
+                continue
+            for name, (x1, y1, x2, y2) in d.parts.items():
+                cls_id = PART_CLASS_MAP[name]
+                cx = (x1 + x2) / 2.0 / w
+                cy = (y1 + y2) / 2.0 / h
+                bw = (x2 - x1) / w
+                bh = (y2 - y1) / h
+                f.write(f"{cls_id} {cx:.6f} {cy:.6f} {bw:.6f} {bh:.6f}\n")
+
+    print(f"[INFO] Parts exportiert: {img_path} + {txt_path}")
+    return txt_path

--- a/tests/test_pose_parts.py
+++ b/tests/test_pose_parts.py
@@ -1,0 +1,85 @@
+import sys, os
+sys.path.append(os.path.dirname(__file__) + "/..")
+
+from detection import Detection
+from pose_parts import compute_parts_for_detection, rescale_keypoints, export_parts_for_training
+
+
+def _blank_keypoints():
+    return [(0.0, 0.0, 0.0) for _ in range(17)]
+
+
+def test_full_person():
+    kps = _blank_keypoints()
+    kps[0] = (100.0, 10.0, 1.0)  # nose
+    kps[5] = (90.0, 40.0, 1.0)
+    kps[6] = (110.0, 40.0, 1.0)
+    kps[11] = (95.0, 80.0, 1.0)
+    kps[12] = (105.0, 80.0, 1.0)
+    det = Detection(80, 0, 120, 100, 0, 0.9, kps)
+    parts = compute_parts_for_detection(det, (100, 200))
+    assert parts is not None
+    assert parts["head"][3] <= parts["upper_body"][1] <= parts["upper_body"][3]
+
+
+def test_missing_shoulder():
+    kps = _blank_keypoints()
+    kps[0] = (100.0, 10.0, 1.0)
+    kps[5] = (90.0, 40.0, 1.0)
+    kps[11] = (95.0, 80.0, 1.0)
+    kps[12] = (105.0, 80.0, 1.0)
+    det = Detection(80, 0, 120, 100, 0, 0.9, kps)
+    parts = compute_parts_for_detection(det, (100, 200))
+    assert parts is not None
+    assert parts["head"][0] < parts["head"][2]
+
+
+def test_missing_hip():
+    kps = _blank_keypoints()
+    kps[0] = (100.0, 10.0, 1.0)
+    kps[5] = (90.0, 40.0, 1.0)
+    kps[6] = (110.0, 40.0, 1.0)
+    det = Detection(80, 0, 120, 100, 0, 0.9, kps)
+    parts = compute_parts_for_detection(det, (100, 200))
+    assert parts is not None
+    # fallback bottom around 60
+    assert 55 <= parts["upper_body"][3] <= 65
+
+
+def test_head_only():
+    kps = _blank_keypoints()
+    kps[0] = (100.0, 10.0, 1.0)
+    det = Detection(80, 0, 120, 100, 0, 0.9, kps)
+    parts = compute_parts_for_detection(det, (100, 200))
+    assert parts is not None
+    assert parts["head"][1] == 10
+
+
+def test_rescale_keypoints():
+    kps = [(10.0, 20.0, 0.9)]
+    scaled = rescale_keypoints(kps, 2.0, 3.0)
+    assert scaled[0][0] == 20.0 and scaled[0][1] == 60.0
+
+
+def test_export_smoke(tmp_path):
+    import pytest
+    np = pytest.importorskip("numpy")
+    pytest.importorskip("cv2")
+
+    kps = _blank_keypoints()
+    kps[0] = (100.0, 10.0, 1.0)
+    kps[5] = (90.0, 40.0, 1.0)
+    kps[6] = (110.0, 40.0, 1.0)
+    kps[11] = (95.0, 80.0, 1.0)
+    kps[12] = (105.0, 80.0, 1.0)
+    det = Detection(80, 0, 120, 100, 0, 0.9, kps)
+    det.parts = compute_parts_for_detection(det, (100, 200))
+    frame = np.zeros((100, 200, 3), dtype=np.uint8)
+    export_parts_for_training(frame, [det], tmp_path)
+    files = list(tmp_path.iterdir())
+    assert any(f.suffix == ".jpg" for f in files)
+    txts = [f for f in files if f.suffix == ".txt"]
+    assert txts
+    content = txts[0].read_text().strip().split()
+    for v in content[1:]:
+        assert 0.0 <= float(v) <= 1.0


### PR DESCRIPTION
## Summary
- integrate YOLOv8 pose model with optional body-part overlays and exports
- add heuristics for head/upper/body boxes and menu/HUD toggles
- provide training export and unit tests for part computation and scaling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a4ad007120832f9019cb3fde919093