### PR TITLE
Simplify head tracking script

### DIFF
--- a/head_tracker.py
+++ b/head_tracker.py
@@ -5,88 +5,73 @@ import torch
 from ultralytics import YOLO
 
 
-def create_tracker():
-    """Return a CSRT tracker instance compatible with current OpenCV version."""
-    if hasattr(cv2, "TrackerCSRT_create"):
-        return cv2.TrackerCSRT_create()
-    return cv2.legacy.TrackerCSRT_create()
+def create_tracker() -> cv2.Tracker:
+    """Create a MOSSE tracker with cross-version compatibility."""
+    return (
+        cv2.TrackerMOSSE_create()
+        if hasattr(cv2, "TrackerMOSSE_create")
+        else cv2.legacy.TrackerMOSSE_create()
+    )
 
 
 class HeadTracker:
-    def __init__(self, model_path: str, conf: float = 0.5, smooth: float = 0.6):
-        self.device = "cuda" if torch.cuda.is_available() else "cpu"
-        self.model = YOLO(model_path)
-        self.model.to(self.device)
+    """Detect once with YOLO, then track a single head using OpenCV."""
+
+    def __init__(self, model_path: str, conf: float = 0.5, alpha: float = 0.3):
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+        self.model = YOLO(model_path).to(device)
         self.conf = conf
-        self.smooth = smooth
-        self.trackers: list[cv2.Tracker] = []
-        self.prev_boxes: list[np.ndarray] = []
+        self.alpha = alpha  # smoothing factor for bounding box
+        self.tracker: cv2.Tracker | None = None
+        self.prev_box: np.ndarray | None = None
 
-    def detect(self, frame: np.ndarray) -> list[tuple[int, int, int, int]]:
-        """Run YOLO and return head boxes as (x, y, w, h)."""
+    def detect(self, frame: np.ndarray) -> tuple[int, int, int, int] | None:
+        """Return first head box as (x, y, w, h)."""
         results = self.model(frame, conf=self.conf, verbose=False)[0]
-        boxes = []
-        if results.boxes is None:
-            return boxes
-        xyxy = results.boxes.xyxy.cpu().numpy().astype(int)
-        for x1, y1, x2, y2 in xyxy:
-            boxes.append((x1, y1, x2 - x1, y2 - y1))
-        return boxes
+        if not results.boxes:
+            return None
+        x1, y1, x2, y2 = results.boxes.xyxy[0].cpu().numpy().astype(int)
+        return x1, y1, x2 - x1, y2 - y1
 
-    def init_trackers(self, frame: np.ndarray, boxes: list[tuple[int, int, int, int]]):
-        self.trackers = []
-        self.prev_boxes = []
-        for box in boxes:
-            tracker = create_tracker()
-            tracker.init(frame, box)
-            self.trackers.append(tracker)
-            self.prev_boxes.append(np.array(box, dtype=np.float32))
+    def init_tracker(self, frame: np.ndarray, box: tuple[int, int, int, int]):
+        self.tracker = create_tracker()
+        self.tracker.init(frame, box)
+        self.prev_box = np.array(box, dtype=np.float32)
 
-    def update(self, frame: np.ndarray) -> list[tuple[int, int, int, int]]:
-        """Update all trackers and return smoothed boxes."""
-        new_trackers = []
-        new_prev = []
-        smoothed_boxes = []
-        for tracker, prev in zip(self.trackers, self.prev_boxes):
-            ok, box = tracker.update(frame)
-            if not ok:
-                continue
-            box = np.array(box, dtype=np.float32)
-            smooth_box = self.smooth * box + (1 - self.smooth) * prev
-            new_trackers.append(tracker)
-            new_prev.append(smooth_box)
-            smoothed_boxes.append(tuple(map(int, smooth_box)))
-        self.trackers = new_trackers
-        self.prev_boxes = new_prev
-        return smoothed_boxes
+    def update(self, frame: np.ndarray) -> tuple[int, int, int, int] | None:
+        if self.tracker is None or self.prev_box is None:
+            return None
+        ok, box = self.tracker.update(frame)
+        if not ok:
+            return None
+        box = np.array(box, dtype=np.float32)
+        self.prev_box = self.alpha * box + (1 - self.alpha) * self.prev_box
+        return tuple(map(int, self.prev_box))
 
 
-def main():
-    model_path = "yolov8n-head.pt"  # replace with your head-specific model
+def main() -> None:
+    model_path = "yolov8n-head.pt"  # path to head detection model
     ht = HeadTracker(model_path)
-    detect_interval = 30
-    frame_idx = 0
 
     with mss.mss() as sct:
-        monitor = sct.monitors[1]  # primary monitor
+        monitor = sct.monitors[1]
+        frame = np.array(sct.grab(monitor))
+        frame = cv2.cvtColor(frame, cv2.COLOR_BGRA2BGR)
+        box = ht.detect(frame)
+        if box is None:
+            return
+        ht.init_tracker(frame, box)
+
         while True:
             frame = np.array(sct.grab(monitor))
             frame = cv2.cvtColor(frame, cv2.COLOR_BGRA2BGR)
-
-            if not ht.trackers or frame_idx % detect_interval == 0:
-                boxes = ht.detect(frame)
-                if boxes:
-                    ht.init_trackers(frame, boxes)
-            boxes = ht.update(frame)
-
-            for x, y, w, h in boxes:
+            box = ht.update(frame)
+            if box:
+                x, y, w, h = box
                 cv2.rectangle(frame, (x, y), (x + w, y + h), (0, 255, 0), 2)
-
             cv2.imshow("Head Tracker", frame)
             if cv2.waitKey(1) & 0xFF == ord("q"):
                 break
-            frame_idx += 1
-
     cv2.destroyAllWindows()
 
 


### PR DESCRIPTION
## Summary
- Replace CSRT tracker with lighter MOSSE tracker after initial YOLO head detection.
- Apply exponential smoothing to bounding-box coordinates for stable head tracking and keep only 'q' to exit.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4b5d2006c832fa2300c484c4f2eb8